### PR TITLE
add python_sql_koans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 cache
+*.pyc

--- a/python_sql_koans/README
+++ b/python_sql_koans/README
@@ -1,0 +1,33 @@
+================
+PYTHON SQL KOANS
+================
+
+Python SQL Koans is inspired by Python Koans (https://bitbucket.org/mcrute/python_koans) 
+which, in turn, was inspired by Edgecase's Ruby Koans (http://rubykoans.com/ )
+
+This in an interactive tutorial for learning to use SQL with Python.  It uses an sqlite3
+database for the example. Those with bitter experience know that Oracle, DB2, MySQL, 
+Postgres all have syntax idiosyncrazies [sic] but effort is made here for the SQL to be
+interchangeable.  
+
+Most tests are 'fixed' by filling the missing parts of assert functions. Eg:
+
+    self.assertEqual(__, 1+2)
+
+which can be fixed by replacing the __ part with the appropriate code:
+
+Downloading Python Koans
+------------------------
+
+Installing Python Koans
+-----------------------
+
+Getting Started
+---------------
+
+From a *nix terminal or windows command prompt go to the python_sql_koans\python_<b>VERSION</b> folder and run:
+
+    python contemplate_sql_koans.py
+
+
+ 

--- a/python_sql_koans/python2/_runner_tests.py
+++ b/python_sql_koans/python2/_runner_tests.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+import unittest
+
+from runner.runner_tests.test_mountain import TestMountain
+from runner.runner_tests.test_sensei import TestSensei
+from runner.runner_tests.test_helper import TestHelper
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestMountain))
+    suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestSensei))
+    suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestHelper))
+    return suite
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())
+    

--- a/python_sql_koans/python2/contemplate_koans.py
+++ b/python_sql_koans/python2/contemplate_koans.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Acknowledgment:
+#
+# Python SQL Koans was highly leveraged from Python Koans by Greg Malcolm and 
+# Mike Crute on bitbucket.org.   Thanks, guys!
+
+## Python Koans is a port of Ruby Koans originally written by Jim Weirich
+## and Joe O'brien of Edgecase. There are some differences and tweaks specific
+## to the Python language, but a great deal of it has been copied wholesale.
+## So thanks guys!
+##
+
+import unittest
+import sys
+
+
+if __name__ == '__main__':        
+    if sys.version_info >= (3, 0):
+        print("\nThis is the Python 2 version of Python SQL Koans, but you are " +
+            "running it with Python 3 or newer!\n\n"
+            "Did you accidentally use the wrong python script? \nTry:\n\n" +
+            "    python contemplate_koans.py\n")
+    else:
+        if sys.version_info < (2, 6):
+            print("\n" +
+                "********************************************************\n" +
+                "WARNING:\n" +
+                "This version of Python SQL Koans was designed for " +
+                "Python 2.6 or greater.\n" +
+                "Your version of Python is older, so this is unlikely " +
+                "to work!\n\n" +
+                "But lets see how far we get...\n" +
+                "********************************************************\n")
+        
+        from runner.mountain import Mountain
+
+        Mountain().walk_the_path(sys.argv)

--- a/python_sql_koans/python2/koans/README
+++ b/python_sql_koans/python2/koans/README
@@ -1,0 +1,13 @@
+This folder contains all the lessons required for python_sql_koans.
+
+Each lesson is expressed as one file for modularity.
+A lesson should encompass a single idea, e.g.:
+-- using the select statement
+-- using the where statement
+-- using group by
+-- using having
+-- connecting to the database
+-- different patterns of expressing sql in python, e.g. using the .format command vs %s and ?,
+ways to do line continuation with opinionated preferences, e.g. +\, ('mytex' [cr] 't' )
+-- ?????
+

--- a/python_sql_koans/python2/koans/about_asserts.py
+++ b/python_sql_koans/python2/koans/about_asserts.py
@@ -15,13 +15,13 @@ class AboutAsserts(Koan):
         """
         Enlightenment may be more easily achieved with appropriate messages.
         """
-        self.assertTrue(True, "This should be true -- Please fix this")
+        self.assertTrue(False, "This should be true -- Please fix this")
 
     def test_fill_in_values(self):
         """
         Sometimes we will ask you to fill in the values
         """
-        self.assertEqual(2, 1 + 1)
+        self.assertEqual(_, 1 + 1)
 
     def test_assert_equality(self):
         """
@@ -29,7 +29,7 @@ class AboutAsserts(Koan):
         """
         expected_value = 2 
         actual_value = 1 + 1
-        self.assertTrue(expected_value == actual_value)
+        self.assertTrue( 0  == actual_value)
 
     def test_a_better_way_of_asserting_equality(self):
         """
@@ -38,7 +38,7 @@ class AboutAsserts(Koan):
         expected_value = 2
         actual_value = 1 + 1
         
-        self.assertEqual(expected_value, actual_value)
+        self.assertEqual(__ , actual_value)
     
     def test_that_unittest_asserts_work_the_same_way_as_python_asserts(self):
         """

--- a/python_sql_koans/python2/koans/about_asserts.py
+++ b/python_sql_koans/python2/koans/about_asserts.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from runner.koan import *
+
+class AboutAsserts(Koan):
+
+    def test_assert_truth(self):
+        """
+        We shall contemplate truth by testing reality, via asserts.
+        """
+        self.assertTrue(True) # This should be true
+    
+    def test_assert_with_message(self):
+        """
+        Enlightenment may be more easily achieved with appropriate messages.
+        """
+        self.assertTrue(True, "This should be true -- Please fix this")
+
+    def test_fill_in_values(self):
+        """
+        Sometimes we will ask you to fill in the values
+        """
+        self.assertEqual(2, 1 + 1)
+
+    def test_assert_equality(self):
+        """
+        To understand reality, we must compare our expectations against reality.
+        """
+        expected_value = 2 
+        actual_value = 1 + 1
+        self.assertTrue(expected_value == actual_value)
+
+    def test_a_better_way_of_asserting_equality(self):
+        """
+        Some ways of asserting equality are better than others.
+        """
+        expected_value = 2
+        actual_value = 1 + 1
+        
+        self.assertEqual(expected_value, actual_value)
+    
+    def test_that_unittest_asserts_work_the_same_way_as_python_asserts(self):
+        """
+        Knowing how things really work is half the battle
+        """
+        
+        # This throws an AssertionError exception
+        assert True
+        

--- a/python_sql_koans/python2/koans/about_groupby.py
+++ b/python_sql_koans/python2/koans/about_groupby.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from runner.koan import *
+
+class AboutGroupBy(Koan):
+
+    def test_assert_truth(self) :
+        """
+        We shall contemplate the truth about selects..
+        """
+        self.assertTrue(___)  #this should be true
+    
+
+

--- a/python_sql_koans/python2/koans/about_groupby.py
+++ b/python_sql_koans/python2/koans/about_groupby.py
@@ -7,9 +7,14 @@ class AboutGroupBy(Koan):
 
     def test_assert_truth(self) :
         """
-        We shall contemplate the truth about selects..
+        We shall contemplate the truth about group by statements..
         """
-        self.assertTrue(___)  #this should be true
+        self.assertTrue(True)  #this should be true
     
+    def test_make_a_group_by_statement(self) :
+        """
+        use group by to see the select results in a different order
+        """
+        pass
 
 

--- a/python_sql_koans/python2/koans/about_groupby_sa.py
+++ b/python_sql_koans/python2/koans/about_groupby_sa.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from runner.koan import *
+
+class AboutGroupByInSqlAlchemy(Koan):
+
+    def test_assert_truth(self) :
+        """
+        We shall contemplate the truth about selects..
+        """
+        self.assertTrue(___)  #this should be true
+    
+
+

--- a/python_sql_koans/python2/koans/about_having.py
+++ b/python_sql_koans/python2/koans/about_having.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from runner.koan import *
+
+class AboutHaving(Koan):
+
+    def test_assert_truth(self) :
+        """
+        We shall contemplate the truth about selects..
+        """
+        self.assertTrue(___)  #this should be true
+    
+
+

--- a/python_sql_koans/python2/koans/about_having_sa.py
+++ b/python_sql_koans/python2/koans/about_having_sa.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from runner.koan import *
+
+class AboutHavingInSqlAlchemy(Koan):
+
+    def test_assert_truth(self) :
+        """
+        We shall contemplate the truth about selects..
+        """
+        self.assertTrue(___)  #this should be true
+    
+
+

--- a/python_sql_koans/python2/koans/about_orderby.py
+++ b/python_sql_koans/python2/koans/about_orderby.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from runner.koan import *
+
+class AboutOrderBy(Koan):
+
+    def test_assert_truth(self) :
+        """
+        We shall contemplate the truth about selects..
+        """
+        self.assertTrue(___)  #this should be true
+    
+
+

--- a/python_sql_koans/python2/koans/about_orderby_sa.py
+++ b/python_sql_koans/python2/koans/about_orderby_sa.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from runner.koan import *
+
+class AboutOrderByInSqlAlchemy(Koan):
+
+    def test_assert_truth(self) :
+        """
+        We shall contemplate the truth about selects..
+        """
+        self.assertTrue(___)  #this should be true
+    
+
+

--- a/python_sql_koans/python2/koans/about_select.py
+++ b/python_sql_koans/python2/koans/about_select.py
@@ -9,7 +9,7 @@ class AboutSelect(Koan):
         """
         We shall contemplate the truth about selects..
         """
-        self.assertTrue(___)  #this should be true
+        self.assertTrue(False)  #this should be true
     
 
 

--- a/python_sql_koans/python2/koans/about_select.py
+++ b/python_sql_koans/python2/koans/about_select.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from runner.koan import *
+
+class AboutSelect(Koan):
+
+    def test_assert_truth(self) :
+        """
+        We shall contemplate the truth about selects..
+        """
+        self.assertTrue(___)  #this should be true
+    
+
+

--- a/python_sql_koans/python2/koans/about_select_sa.py
+++ b/python_sql_koans/python2/koans/about_select_sa.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from runner.koan import *
+
+class AboutSelectInSqlAlchemy(Koan):
+
+    def test_assert_truth(self) :
+        """
+        We shall contemplate the truth about selects..
+        """
+        self.assertTrue(___)  #this should be true
+    
+
+

--- a/python_sql_koans/python2/koans/about_where.py
+++ b/python_sql_koans/python2/koans/about_where.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from runner.koan import *
+
+class AboutWhere(Koan):
+
+    def test_assert_truth(self) :
+        """
+        We shall contemplate the truth about selects..
+        """
+        self.assertTrue(___)  #this should be true
+    
+
+

--- a/python_sql_koans/python2/koans/about_where.py
+++ b/python_sql_koans/python2/koans/about_where.py
@@ -9,7 +9,7 @@ class AboutWhere(Koan):
         """
         We shall contemplate the truth about selects..
         """
-        self.assertTrue(___)  #this should be true
+        self.assertTrue(False)  #this should be true
     
 
 

--- a/python_sql_koans/python2/koans/about_where_sa.py
+++ b/python_sql_koans/python2/koans/about_where_sa.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from runner.koan import *
+
+class AboutWhereInSqlAlchemy(Koan):
+
+    def test_assert_truth(self) :
+        """
+        We shall contemplate the truth about selects..
+        """
+        self.assertTrue(___)  #this should be true
+    
+
+

--- a/python_sql_koans/python2/libs/__init__.py
+++ b/python_sql_koans/python2/libs/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Dummy file to support python package hierarchy

--- a/python_sql_koans/python2/libs/colorama/LICENSE-colorama
+++ b/python_sql_koans/python2/libs/colorama/LICENSE-colorama
@@ -1,0 +1,33 @@
+Copyright (c) 2010 Jonathan Hartley <tartley@tartley.com>
+
+Released under the New BSD license (reproduced below), or alternatively you may
+use this software under any OSI approved open source license such as those at
+http://opensource.org/licenses/alphabetical
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name(s) of the copyright holders, nor those of its contributors
+  may be used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/python_sql_koans/python2/libs/colorama/__init__.py
+++ b/python_sql_koans/python2/libs/colorama/__init__.py
@@ -1,0 +1,6 @@
+from .initialise import init
+from .ansi import Fore, Back, Style
+from .ansitowin32 import AnsiToWin32
+
+VERSION = '0.1.18'
+

--- a/python_sql_koans/python2/libs/colorama/ansi.py
+++ b/python_sql_koans/python2/libs/colorama/ansi.py
@@ -1,0 +1,49 @@
+'''
+This module generates ANSI character codes to printing colors to terminals.
+See: http://en.wikipedia.org/wiki/ANSI_escape_code
+'''
+
+CSI = '\033['
+
+def code_to_chars(code):
+    return CSI + str(code) + 'm'
+
+class AnsiCodes(object):
+    def __init__(self, codes):
+        for name in dir(codes):
+            if not name.startswith('_'):
+                value = getattr(codes, name)
+                setattr(self, name, code_to_chars(value))
+
+class AnsiFore:
+    BLACK   = 30
+    RED     = 31
+    GREEN   = 32
+    YELLOW  = 33
+    BLUE    = 34
+    MAGENTA = 35
+    CYAN    = 36
+    WHITE   = 37
+    RESET   = 39
+
+class AnsiBack:
+    BLACK   = 40
+    RED     = 41
+    GREEN   = 42
+    YELLOW  = 43
+    BLUE    = 44
+    MAGENTA = 45
+    CYAN    = 46
+    WHITE   = 47
+    RESET   = 49
+
+class AnsiStyle:
+    BRIGHT    = 1
+    DIM       = 2
+    NORMAL    = 22
+    RESET_ALL = 0
+
+Fore = AnsiCodes( AnsiFore )
+Back = AnsiCodes( AnsiBack )
+Style = AnsiCodes( AnsiStyle )
+

--- a/python_sql_koans/python2/libs/colorama/ansitowin32.py
+++ b/python_sql_koans/python2/libs/colorama/ansitowin32.py
@@ -1,0 +1,176 @@
+
+import re
+import sys
+
+from .ansi import AnsiFore, AnsiBack, AnsiStyle, Style
+from .winterm import WinTerm, WinColor, WinStyle
+from .win32 import windll
+
+
+if windll is not None:
+    winterm = WinTerm()
+
+
+def is_a_tty(stream):
+    return hasattr(stream, 'isatty') and stream.isatty()
+
+
+class StreamWrapper(object):
+    '''
+    Wraps a stream (such as stdout), acting as a transparent proxy for all
+    attribute access apart from method 'write()', which is delegated to our
+    Converter instance.
+    '''
+    def __init__(self, wrapped, converter):
+        # double-underscore everything to prevent clashes with names of
+        # attributes on the wrapped stream object.
+        self.__wrapped = wrapped
+        self.__convertor = converter
+
+    def __getattr__(self, name):
+        return getattr(self.__wrapped, name)
+
+    def write(self, text):
+        self.__convertor.write(text)
+
+
+class AnsiToWin32(object):
+    '''
+    Implements a 'write()' method which, on Windows, will strip ANSI character
+    sequences from the text, and if outputting to a tty, will convert them into
+    win32 function calls.
+    '''
+    ANSI_RE = re.compile('\033\[((?:\d|;)*)([a-zA-Z])')
+
+    def __init__(self, wrapped, convert=None, strip=None, autoreset=False):
+        # The wrapped stream (normally sys.stdout or sys.stderr)
+        self.wrapped = wrapped
+
+        # should we reset colors to defaults after every .write()
+        self.autoreset = autoreset
+
+        # create the proxy wrapping our output stream
+        self.stream = StreamWrapper(wrapped, self)
+
+        on_windows = sys.platform.startswith('win')
+
+        # should we strip ANSI sequences from our output?
+        if strip is None:
+            strip = on_windows
+        self.strip = strip
+
+        # should we should convert ANSI sequences into win32 calls?
+        if convert is None:
+            convert = on_windows and is_a_tty(wrapped)
+        self.convert = convert
+
+        # dict of ansi codes to win32 functions and parameters
+        self.win32_calls = self.get_win32_calls()
+
+        # are we wrapping stderr?
+        self.on_stderr = self.wrapped is sys.stderr
+
+
+    def should_wrap(self):
+        '''
+        True if this class is actually needed. If false, then the output
+        stream will not be affected, nor will win32 calls be issued, so
+        wrapping stdout is not actually required. This will generally be
+        False on non-Windows platforms, unless optional functionality like
+        autoreset has been requested using kwargs to init()
+        '''
+        return self.convert or self.strip or self.autoreset
+
+
+    def get_win32_calls(self):
+        if self.convert and winterm:
+            return {
+                AnsiStyle.RESET_ALL: (winterm.reset_all, ),
+                AnsiStyle.BRIGHT: (winterm.style, WinStyle.BRIGHT),
+                AnsiStyle.DIM: (winterm.style, WinStyle.NORMAL),
+                AnsiStyle.NORMAL: (winterm.style, WinStyle.NORMAL),
+                AnsiFore.BLACK: (winterm.fore, WinColor.BLACK),
+                AnsiFore.RED: (winterm.fore, WinColor.RED),
+                AnsiFore.GREEN: (winterm.fore, WinColor.GREEN),
+                AnsiFore.YELLOW: (winterm.fore, WinColor.YELLOW),
+                AnsiFore.BLUE: (winterm.fore, WinColor.BLUE),
+                AnsiFore.MAGENTA: (winterm.fore, WinColor.MAGENTA),
+                AnsiFore.CYAN: (winterm.fore, WinColor.CYAN),
+                AnsiFore.WHITE: (winterm.fore, WinColor.GREY),
+                AnsiFore.RESET: (winterm.fore, ),
+                AnsiBack.BLACK: (winterm.back, WinColor.BLACK),
+                AnsiBack.RED: (winterm.back, WinColor.RED),
+                AnsiBack.GREEN: (winterm.back, WinColor.GREEN),
+                AnsiBack.YELLOW: (winterm.back, WinColor.YELLOW),
+                AnsiBack.BLUE: (winterm.back, WinColor.BLUE),
+                AnsiBack.MAGENTA: (winterm.back, WinColor.MAGENTA),
+                AnsiBack.CYAN: (winterm.back, WinColor.CYAN),
+                AnsiBack.WHITE: (winterm.back, WinColor.GREY),
+                AnsiBack.RESET: (winterm.back, ),
+            }
+
+
+    def write(self, text):
+        if self.strip or self.convert:
+            self.write_and_convert(text)
+        else:
+            self.wrapped.write(text)
+            self.wrapped.flush()
+        if self.autoreset:
+            self.reset_all()
+        
+
+    def reset_all(self):
+        if self.convert:
+            self.call_win32('m', (0,))
+        else:
+            self.wrapped.write(Style.RESET_ALL)
+
+
+    def write_and_convert(self, text):
+        '''
+        Write the given text to our wrapped stream, stripping any ANSI
+        sequences from the text, and optionally converting them into win32
+        calls.
+        '''
+        cursor = 0
+        for match in self.ANSI_RE.finditer(text):
+            start, end = match.span()
+            self.write_plain_text(text, cursor, start)
+            self.convert_ansi(*match.groups())
+            cursor = end
+        self.write_plain_text(text, cursor, len(text))
+
+
+    def write_plain_text(self, text, start, end):
+        if start < end:
+            self.wrapped.write(text[start:end])
+            self.wrapped.flush()
+
+
+    def convert_ansi(self, paramstring, command):
+        if self.convert:
+            params = self.extract_params(paramstring)
+            self.call_win32(command, params)
+
+
+    def extract_params(self, paramstring):
+        def split(paramstring):
+            for p in paramstring.split(';'):
+                if p != '':
+                    yield int(p)
+        return tuple(split(paramstring))
+
+
+    def call_win32(self, command, params):
+        if params == []:
+            params = [0]
+        if command == 'm':
+            for param in params:
+                if param in self.win32_calls:
+                    func_args = self.win32_calls[param]
+                    func = func_args[0]
+                    args = func_args[1:]
+                    kwargs = dict(on_stderr=self.on_stderr)
+                    func(*args, **kwargs)
+

--- a/python_sql_koans/python2/libs/colorama/initialise.py
+++ b/python_sql_koans/python2/libs/colorama/initialise.py
@@ -1,0 +1,38 @@
+import atexit
+import sys
+
+from .ansitowin32 import AnsiToWin32
+
+
+orig_stdout = sys.stdout
+orig_stderr = sys.stderr
+
+atexit_done = False
+
+
+def reset_all():
+    AnsiToWin32(orig_stdout).reset_all()
+
+
+def init(autoreset=False, convert=None, strip=None, wrap=True):
+
+    if wrap==False and (autoreset==True or convert==True or strip==True):
+        raise ValueError('wrap=False conflicts with any other arg=True')
+
+    sys.stdout = wrap_stream(orig_stdout, convert, strip, autoreset, wrap)
+    sys.stderr = wrap_stream(orig_stderr, convert, strip, autoreset, wrap)
+
+    global atexit_done
+    if not atexit_done:
+        atexit.register(reset_all)
+        atexit_done = True
+
+
+def wrap_stream(stream, convert, strip, autoreset, wrap):
+    if wrap:
+        wrapper = AnsiToWin32(stream,
+            convert=convert, strip=strip, autoreset=autoreset)
+        if wrapper.should_wrap():
+            stream = wrapper.stream
+    return stream
+

--- a/python_sql_koans/python2/libs/colorama/win32.py
+++ b/python_sql_koans/python2/libs/colorama/win32.py
@@ -1,0 +1,95 @@
+
+# from winbase.h
+STDOUT = -11
+STDERR = -12
+
+try:
+    from ctypes import windll
+except ImportError:
+    windll = None
+    SetConsoleTextAttribute = lambda *_: None
+else:
+    from ctypes import (
+        byref, Structure, c_char, c_short, c_uint32, c_ushort
+    )
+
+    handles = {
+        STDOUT: windll.kernel32.GetStdHandle(STDOUT),
+        STDERR: windll.kernel32.GetStdHandle(STDERR),
+    }
+
+    SHORT = c_short
+    WORD = c_ushort
+    DWORD = c_uint32
+    TCHAR = c_char
+
+    class COORD(Structure):
+        """struct in wincon.h"""
+        _fields_ = [
+            ('X', SHORT),
+            ('Y', SHORT),
+        ]
+
+    class  SMALL_RECT(Structure):
+        """struct in wincon.h."""
+        _fields_ = [
+            ("Left", SHORT),
+            ("Top", SHORT),
+            ("Right", SHORT),
+            ("Bottom", SHORT),
+        ]
+
+    class CONSOLE_SCREEN_BUFFER_INFO(Structure):
+        """struct in wincon.h."""
+        _fields_ = [
+            ("dwSize", COORD),
+            ("dwCursorPosition", COORD),
+            ("wAttributes", WORD),
+            ("srWindow", SMALL_RECT),
+            ("dwMaximumWindowSize", COORD),
+        ]
+
+    def GetConsoleScreenBufferInfo(stream_id):
+        handle = handles[stream_id]
+        csbi = CONSOLE_SCREEN_BUFFER_INFO()
+        success = windll.kernel32.GetConsoleScreenBufferInfo(
+            handle, byref(csbi))
+        # This fails when imported via setup.py when installing using 'pip'
+        # presumably the fix is that running setup.py should not trigger all
+        # this activity.
+        # assert success
+        return csbi
+
+    def SetConsoleTextAttribute(stream_id, attrs):
+        handle = handles[stream_id]
+        success = windll.kernel32.SetConsoleTextAttribute(handle, attrs)
+        assert success
+
+    def SetConsoleCursorPosition(stream_id, position):
+        handle = handles[stream_id]
+        position = COORD(*position)
+        success = windll.kernel32.SetConsoleCursorPosition(handle, position)
+        assert success
+
+    def FillConsoleOutputCharacter(stream_id, char, length, start):
+        handle = handles[stream_id]
+        char = TCHAR(char)
+        length = DWORD(length)
+        start = COORD(*start)
+        num_written = DWORD(0)
+        # AttributeError: function 'FillConsoleOutputCharacter' not found
+        # could it just be that my types are wrong?
+        success = windll.kernel32.FillConsoleOutputCharacter(
+            handle, char, length, start, byref(num_written))
+        assert success
+        return num_written.value
+
+
+if __name__=='__main__':
+    x = GetConsoleScreenBufferInfo(STDOUT)
+    print(x.dwSize)
+    print(x.dwCursorPosition)
+    print(x.wAttributes)
+    print(x.srWindow)
+    print(x.dwMaximumWindowSize)
+

--- a/python_sql_koans/python2/libs/colorama/winterm.py
+++ b/python_sql_koans/python2/libs/colorama/winterm.py
@@ -1,0 +1,69 @@
+
+from . import win32
+
+
+# from wincon.h
+class WinColor(object):
+    BLACK   = 0
+    BLUE    = 1
+    GREEN   = 2
+    CYAN    = 3
+    RED     = 4
+    MAGENTA = 5
+    YELLOW  = 6
+    GREY    = 7
+
+# from wincon.h
+class WinStyle(object):
+    NORMAL = 0x00 # dim text, dim background
+    BRIGHT = 0x08 # bright text, dim background
+
+
+class WinTerm(object):
+
+    def __init__(self):
+        self._default = \
+            win32.GetConsoleScreenBufferInfo(win32.STDOUT).wAttributes
+        self.set_attrs(self._default)
+        self._default_fore = self._fore
+        self._default_back = self._back
+        self._default_style = self._style
+
+    def get_attrs(self):
+        return self._fore + self._back * 16 + self._style
+
+    def set_attrs(self, value):
+        self._fore = value & 7
+        self._back = (value >> 4) & 7
+        self._style = value & WinStyle.BRIGHT
+
+    def reset_all(self, on_stderr=None):
+        self.set_attrs(self._default)
+        self.set_console(attrs=self._default)
+
+    def fore(self, fore=None, on_stderr=False):
+        if fore is None:
+            fore = self._default_fore
+        self._fore = fore
+        self.set_console(on_stderr=on_stderr)
+
+    def back(self, back=None, on_stderr=False):
+        if back is None:
+            back = self._default_back
+        self._back = back
+        self.set_console(on_stderr=on_stderr)
+
+    def style(self, style=None, on_stderr=False):
+        if style is None:
+            style = self._default_style
+        self._style = style
+        self.set_console(on_stderr=on_stderr)
+
+    def set_console(self, attrs=None, on_stderr=False):
+        if attrs is None:
+            attrs = self.get_attrs()
+        handle = win32.STDOUT
+        if on_stderr:
+            handle = win32.STDERR
+        win32.SetConsoleTextAttribute(handle, attrs)
+

--- a/python_sql_koans/python2/libs/mock.py
+++ b/python_sql_koans/python2/libs/mock.py
@@ -1,0 +1,271 @@
+# mock.py
+# Test tools for mocking and patching.
+# Copyright (C) 2007-2009 Michael Foord
+# E-mail: fuzzyman AT voidspace DOT org DOT uk
+
+# mock 0.6.0
+# http://www.voidspace.org.uk/python/mock/
+
+# Released subject to the BSD License
+# Please see http://www.voidspace.org.uk/python/license.shtml
+
+# Scripts maintained at http://www.voidspace.org.uk/python/index.shtml
+# Comments, suggestions and bug reports welcome.
+
+
+__all__ = (
+    'Mock',
+    'patch',
+    'patch_object',
+    'sentinel',
+    'DEFAULT'
+)
+
+__version__ = '0.6.0 modified by Greg Malcolm'
+
+class SentinelObject(object):
+    def __init__(self, name):
+        self.name = name
+        
+    def __repr__(self):
+        return '<SentinelObject "{0!s}">'.format(self.name)
+
+
+class Sentinel(object):
+    def __init__(self):
+        self._sentinels = {}
+        
+    def __getattr__(self, name):
+        return self._sentinels.setdefault(name, SentinelObject(name))
+    
+    
+sentinel = Sentinel()
+
+DEFAULT = sentinel.DEFAULT
+
+class OldStyleClass:
+    pass
+ClassType = type(OldStyleClass)
+
+def _is_magic(name):
+    return '__{0!s}__'.format(name[2:-2]) == name
+
+def _copy(value):
+    if type(value) in (dict, list, tuple, set):
+        return type(value)(value)
+    return value
+
+
+class Mock(object):
+
+    def __init__(self, spec=None, side_effect=None, return_value=DEFAULT, 
+                 name=None, parent=None, wraps=None):
+        self._parent = parent
+        self._name = name
+        if spec is not None and not isinstance(spec, list):
+            spec = [member for member in dir(spec) if not _is_magic(member)]
+        
+        self._methods = spec
+        self._children = {}
+        self._return_value = return_value
+        self.side_effect = side_effect
+        self._wraps = wraps
+        
+        self.reset_mock()
+        
+
+    def reset_mock(self):
+        self.called = False
+        self.call_args = None
+        self.call_count = 0
+        self.call_args_list = []
+        self.method_calls = []
+        for child in self._children.values():
+            child.reset_mock()
+        if isinstance(self._return_value, Mock):
+            self._return_value.reset_mock()
+        
+    
+    def __get_return_value(self):
+        if self._return_value is DEFAULT:
+            self._return_value = Mock()
+        return self._return_value
+    
+    def __set_return_value(self, value):
+        self._return_value = value
+        
+    return_value = property(__get_return_value, __set_return_value)
+
+
+    def __call__(self, *args, **kwargs):
+        self.called = True
+        self.call_count += 1
+        self.call_args = (args, kwargs)
+        self.call_args_list.append((args, kwargs))
+        
+        parent = self._parent
+        name = self._name
+        while parent is not None:
+            parent.method_calls.append((name, args, kwargs))
+            if parent._parent is None:
+                break
+            name = parent._name + '.' + name
+            parent = parent._parent
+        
+        ret_val = DEFAULT
+        if self.side_effect is not None:
+            if (isinstance(self.side_effect, Exception) or 
+                isinstance(self.side_effect, (type, ClassType)) and
+                issubclass(self.side_effect, Exception)):
+                raise self.side_effect
+            
+            ret_val = self.side_effect(*args, **kwargs)
+            if ret_val is DEFAULT:
+                ret_val = self.return_value
+        
+        if self._wraps is not None and self._return_value is DEFAULT:
+            return self._wraps(*args, **kwargs)
+        if ret_val is DEFAULT:
+            ret_val = self.return_value
+        return ret_val
+    
+    
+    def __getattr__(self, name):
+        if self._methods is not None:
+            if name not in self._methods:
+                raise AttributeError("Mock object has no attribute '{0!s}'".format(name))
+        elif _is_magic(name):
+            raise AttributeError(name)
+        
+        if name not in self._children:
+            wraps = None
+            if self._wraps is not None:
+                wraps = getattr(self._wraps, name)
+            self._children[name] = Mock(parent=self, name=name, wraps=wraps)
+            
+        return self._children[name]
+    
+    
+    def assert_called_with(self, *args, **kwargs):
+        assert self.call_args == (args, kwargs), 'Expected: {0!s}\nCalled with: {1!s}'.format((args, kwargs), self.call_args)
+        
+
+def _dot_lookup(thing, comp, import_path):
+    try:
+        return getattr(thing, comp)
+    except AttributeError:
+        __import__(import_path)
+        return getattr(thing, comp)
+
+
+def _importer(target):
+    components = target.split('.')
+    import_path = components.pop(0)
+    thing = __import__(import_path)
+
+    for comp in components:
+        import_path += ".{0!s}".format(comp)
+        thing = _dot_lookup(thing, comp, import_path)
+    return thing
+
+
+class _patch(object):
+    def __init__(self, target, attribute, new, spec, create):
+        self.target = target
+        self.attribute = attribute
+        self.new = new
+        self.spec = spec
+        self.create = create
+        self.has_local = False
+
+
+    def __call__(self, func):
+        if hasattr(func, 'patchings'):
+            func.patchings.append(self)
+            return func
+
+        def patched(*args, **keywargs):
+            # don't use a with here (backwards compatability with 2.5)
+            extra_args = []
+            for patching in patched.patchings:
+                arg = patching.__enter__()
+                if patching.new is DEFAULT:
+                    extra_args.append(arg)
+            args += tuple(extra_args)
+            try:
+                return func(*args, **keywargs)
+            finally:
+                for patching in getattr(patched, 'patchings', []):
+                    patching.__exit__()
+
+        patched.patchings = [self]
+        patched.__name__ = func.__name__ 
+        patched.compat_co_firstlineno = getattr(func, "compat_co_firstlineno", 
+                                                func.func_code.co_firstlineno)
+        return patched
+
+
+    def get_original(self):
+        target = self.target
+        name = self.attribute
+        create = self.create
+        
+        original = DEFAULT
+        if _has_local_attr(target, name):
+            try:
+                original = target.__dict__[name]
+            except AttributeError:
+                # for instances of classes with slots, they have no __dict__
+                original = getattr(target, name)
+        elif not create and not hasattr(target, name):
+            raise AttributeError("{0!s} does not have the attribute {1!r}".format(target, name))
+        return original
+
+    
+    def __enter__(self):
+        new, spec, = self.new, self.spec
+        original = self.get_original()
+        if new is DEFAULT:
+            # XXXX what if original is DEFAULT - shouldn't use it as a spec
+            inherit = False
+            if spec == True:
+                # set spec to the object we are replacing
+                spec = original
+                if isinstance(spec, (type, ClassType)):
+                    inherit = True
+            new = Mock(spec=spec)
+            if inherit:
+                new.return_value = Mock(spec=spec)
+        self.temp_original = original
+        setattr(self.target, self.attribute, new)
+        return new
+
+
+    def __exit__(self, *_):
+        if self.temp_original is not DEFAULT:
+            setattr(self.target, self.attribute, self.temp_original)
+        else:
+            delattr(self.target, self.attribute)
+        del self.temp_original
+            
+                
+def patch_object(target, attribute, new=DEFAULT, spec=None, create=False):
+    return _patch(target, attribute, new, spec, create)
+
+
+def patch(target, new=DEFAULT, spec=None, create=False):
+    try:
+        target, attribute = target.rsplit('.', 1)    
+    except (TypeError, ValueError):
+        raise TypeError("Need a valid target to patch. You supplied: {0!r}".format(target,))
+    target = _importer(target)
+    return _patch(target, attribute, new, spec, create)
+
+
+
+def _has_local_attr(obj, name):
+    try:
+        return name in vars(obj)
+    except TypeError:
+        # objects without a __dict__
+        return hasattr(obj, name)

--- a/python_sql_koans/python2/runner/__init__.py
+++ b/python_sql_koans/python2/runner/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Namespace: runner
+

--- a/python_sql_koans/python2/runner/helper.py
+++ b/python_sql_koans/python2/runner/helper.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+def cls_name(obj):
+    return obj.__class__.__name__

--- a/python_sql_koans/python2/runner/koan.py
+++ b/python_sql_koans/python2/runner/koan.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+import re
+
+# Starting a classname or attribute with an underscore normally implies Private scope.
+# However, we are making an exception for __ and ___.
+
+__all__ = [ "__", "___", "____", "_____", "Koan" ]
+
+__ = "-=> FILL ME IN! <=-"
+
+class ___(Exception):
+    pass
+
+____ = "-=> TRUE OR FALSE? <=-"
+
+_____ = 0
+
+
+class Koan(unittest.TestCase):
+    def assertMatch(self, pattern, string, msg=None):
+        """
+        Throw an exception if the regular expresson pattern is matched
+        """
+        # Not part of unittest, but convenient for some koans tests
+        m = re.search(pattern, string)
+        if not m or not m.group(0):
+            raise self.failureException, \
+                (msg or '{0!r} does not match {1!r}'.format(pattern, string))
+
+    def assertNoMatch(self, pattern, string, msg=None):
+        """
+        Throw an exception if the regular expresson pattern is not matched
+        """
+        m = re.search(pattern, string)
+        if m and m.group(0):
+            raise self.failureException, \
+                (msg or '{0!r} matches {1!r}'.format(pattern, string))

--- a/python_sql_koans/python2/runner/mockable_test_result.py
+++ b/python_sql_koans/python2/runner/mockable_test_result.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+
+# Needed to stop unittest.TestResult itself getting Mocked out of existence,
+# which is a problem when testing the helper classes! (It confuses the runner)
+
+class MockableTestResult(unittest.TestResult):
+    pass

--- a/python_sql_koans/python2/runner/mountain.py
+++ b/python_sql_koans/python2/runner/mountain.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+import sys
+
+import path_to_enlightenment
+from sensei import Sensei
+from writeln_decorator import WritelnDecorator
+
+class Mountain:
+    def __init__(self):
+        self.stream = WritelnDecorator(sys.stdout)
+        self.tests = path_to_enlightenment.koans()
+        self.lesson = Sensei(self.stream)
+    
+    def walk_the_path(self, args=None):
+        "Run the koans tests with a custom runner output."
+        
+        if args and len(args) >=2:
+            self.tests = unittest.TestLoader().loadTestsFromName("koans." + args[1])
+
+        self.tests(self.lesson)
+        self.lesson.learn()
+        return self.lesson

--- a/python_sql_koans/python2/runner/path_to_enlightenment.py
+++ b/python_sql_koans/python2/runner/path_to_enlightenment.py
@@ -7,6 +7,17 @@ import unittest
 
 from koans.about_asserts import AboutAsserts
 from koans.about_select import AboutSelect
+from koans.about_where import AboutWhere
+from koans.about_groupby import AboutGroupBy
+from koans.about_having import AboutHaving
+from koans.about_orderby import AboutOrderBy
+from koans.about_select_sa import AboutSelectInSqlAlchemy
+from koans.about_where_sa import AboutWhereInSqlAlchemy
+from koans.about_groupby_sa import AboutGroupByInSqlAlchemy
+from koans.about_having_sa import AboutHavingInSqlAlchemy
+from koans.about_orderby_sa import AboutOrderByInSqlAlchemy
+
+
 #from koans.about_none import AboutNone
 #from koans.about_lists import AboutLists
 #from koans.about_list_assignments import AboutListAssignments
@@ -49,8 +60,16 @@ def koans():
     suite = unittest.TestSuite()
     loader.sortTestMethodsUsing = None
     suite.addTests(loader.loadTestsFromTestCase(AboutSelect))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutAsserts))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutNone))
+    suite.addTests(loader.loadTestsFromTestCase(AboutAsserts))
+    suite.addTests(loader.loadTestsFromTestCase(AboutWhere))
+    suite.addTests(loader.loadTestsFromTestCase(AboutHaving))
+    suite.addTests(loader.loadTestsFromTestCase(AboutOrderBy))
+    suite.addTests(loader.loadTestsFromTestCase(AboutGroupBy))
+    suite.addTests(loader.loadTestsFromTestCase(AboutSelectInSqlAlchemy))
+    suite.addTests(loader.loadTestsFromTestCase(AboutWhereInSqlAlchemy))
+    suite.addTests(loader.loadTestsFromTestCase(AboutHavingInSqlAlchemy))
+    suite.addTests(loader.loadTestsFromTestCase(AboutOrderByInSqlAlchemy))
+    suite.addTests(loader.loadTestsFromTestCase(AboutGroupByInSqlAlchemy))
 #    suite.addTests(loader.loadTestsFromTestCase(AboutLists))
 #    suite.addTests(loader.loadTestsFromTestCase(AboutListAssignments))
 #    suite.addTests(loader.loadTestsFromTestCase(AboutDictionaries))

--- a/python_sql_koans/python2/runner/path_to_enlightenment.py
+++ b/python_sql_koans/python2/runner/path_to_enlightenment.py
@@ -5,7 +5,7 @@
 
 import unittest
 
-from koans.about_asserts import AboutAsserts
+#from koans.about_asserts import AboutAsserts
 from koans.about_select import AboutSelect
 from koans.about_where import AboutWhere
 from koans.about_groupby import AboutGroupBy
@@ -18,49 +18,13 @@ from koans.about_having_sa import AboutHavingInSqlAlchemy
 from koans.about_orderby_sa import AboutOrderByInSqlAlchemy
 
 
-#from koans.about_none import AboutNone
-#from koans.about_lists import AboutLists
-#from koans.about_list_assignments import AboutListAssignments
-#from koans.about_dictionaries import AboutDictionaries
-#from koans.about_strings import AboutStrings
-#from koans.about_tuples import AboutTuples
-#from koans.about_methods import AboutMethods
-#from koans.about_control_statements import AboutControlStatements
-#from koans.about_true_and_false import AboutTrueAndFalse
-#from koans.about_sets import AboutSets
-#from koans.about_triangle_project import AboutTriangleProject
-#from koans.about_exceptions import AboutExceptions
-#from koans.about_triangle_project2 import AboutTriangleProject2
-#from koans.about_iteration import AboutIteration
-#from koans.about_generators import AboutGenerators
-#from koans.about_lambdas import AboutLambdas
-#from koans.about_scoring_project import AboutScoringProject
-#from koans.about_classes import AboutClasses
-#from koans.about_new_style_classes import AboutNewStyleClasses
-#from koans.about_with_statements import AboutWithStatements
-#from koans.about_monkey_patching import AboutMonkeyPatching
-#from koans.about_dice_project import AboutDiceProject
-#from koans.about_method_bindings import AboutMethodBindings
-#from koans.about_decorating_with_functions import AboutDecoratingWithFunctions
-#from koans.about_decorating_with_classes import AboutDecoratingWithClasses
-#from koans.about_inheritance import AboutInheritance
-#from koans.about_multiple_inheritance import AboutMultipleInheritance
-#from koans.about_regex import AboutRegex
-#from koans.about_scope import AboutScope
-#from koans.about_modules import AboutModules
-#from koans.about_packages import AboutPackages
-#from koans.about_class_attributes import AboutClassAttributes
-#from koans.about_attribute_access import AboutAttributeAccess
-#from koans.about_deleting_objects import AboutDeletingObjects
-#from koans.about_proxy_object_project import *
-#from koans.about_extra_credit import AboutExtraCredit
 
 def koans():
     loader = unittest.TestLoader()
     suite = unittest.TestSuite()
     loader.sortTestMethodsUsing = None
-    suite.addTests(loader.loadTestsFromTestCase(AboutSelect))
     suite.addTests(loader.loadTestsFromTestCase(AboutAsserts))
+    suite.addTests(loader.loadTestsFromTestCase(AboutSelect))
     suite.addTests(loader.loadTestsFromTestCase(AboutWhere))
     suite.addTests(loader.loadTestsFromTestCase(AboutHaving))
     suite.addTests(loader.loadTestsFromTestCase(AboutOrderBy))
@@ -70,40 +34,5 @@ def koans():
     suite.addTests(loader.loadTestsFromTestCase(AboutHavingInSqlAlchemy))
     suite.addTests(loader.loadTestsFromTestCase(AboutOrderByInSqlAlchemy))
     suite.addTests(loader.loadTestsFromTestCase(AboutGroupByInSqlAlchemy))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutLists))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutListAssignments))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutDictionaries))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutStrings))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutTuples))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutMethods))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutControlStatements))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutTrueAndFalse))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutSets))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutTriangleProject))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutExceptions))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutTriangleProject2))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutIteration))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutGenerators))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutLambdas))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutScoringProject))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutClasses))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutNewStyleClasses))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutWithStatements))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutMonkeyPatching))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutDiceProject))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutMethodBindings))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutDecoratingWithFunctions))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutDecoratingWithClasses))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutInheritance))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutMultipleInheritance))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutScope))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutModules))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutPackages))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutClassAttributes))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutAttributeAccess))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutDeletingObjects))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutProxyObjectProject))
-#    suite.addTests(loader.loadTestsFromTestCase(TelevisionTest))
-#    suite.addTests(loader.loadTestsFromTestCase(AboutExtraCredit))
 
     return suite

--- a/python_sql_koans/python2/runner/path_to_enlightenment.py
+++ b/python_sql_koans/python2/runner/path_to_enlightenment.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# The path to enlightenment starts with the following:
+
+import unittest
+
+from koans.about_asserts import AboutAsserts
+from koans.about_select import AboutSelect
+#from koans.about_none import AboutNone
+#from koans.about_lists import AboutLists
+#from koans.about_list_assignments import AboutListAssignments
+#from koans.about_dictionaries import AboutDictionaries
+#from koans.about_strings import AboutStrings
+#from koans.about_tuples import AboutTuples
+#from koans.about_methods import AboutMethods
+#from koans.about_control_statements import AboutControlStatements
+#from koans.about_true_and_false import AboutTrueAndFalse
+#from koans.about_sets import AboutSets
+#from koans.about_triangle_project import AboutTriangleProject
+#from koans.about_exceptions import AboutExceptions
+#from koans.about_triangle_project2 import AboutTriangleProject2
+#from koans.about_iteration import AboutIteration
+#from koans.about_generators import AboutGenerators
+#from koans.about_lambdas import AboutLambdas
+#from koans.about_scoring_project import AboutScoringProject
+#from koans.about_classes import AboutClasses
+#from koans.about_new_style_classes import AboutNewStyleClasses
+#from koans.about_with_statements import AboutWithStatements
+#from koans.about_monkey_patching import AboutMonkeyPatching
+#from koans.about_dice_project import AboutDiceProject
+#from koans.about_method_bindings import AboutMethodBindings
+#from koans.about_decorating_with_functions import AboutDecoratingWithFunctions
+#from koans.about_decorating_with_classes import AboutDecoratingWithClasses
+#from koans.about_inheritance import AboutInheritance
+#from koans.about_multiple_inheritance import AboutMultipleInheritance
+#from koans.about_regex import AboutRegex
+#from koans.about_scope import AboutScope
+#from koans.about_modules import AboutModules
+#from koans.about_packages import AboutPackages
+#from koans.about_class_attributes import AboutClassAttributes
+#from koans.about_attribute_access import AboutAttributeAccess
+#from koans.about_deleting_objects import AboutDeletingObjects
+#from koans.about_proxy_object_project import *
+#from koans.about_extra_credit import AboutExtraCredit
+
+def koans():
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    loader.sortTestMethodsUsing = None
+    suite.addTests(loader.loadTestsFromTestCase(AboutSelect))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutAsserts))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutNone))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutLists))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutListAssignments))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutDictionaries))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutStrings))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutTuples))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutMethods))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutControlStatements))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutTrueAndFalse))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutSets))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutTriangleProject))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutExceptions))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutTriangleProject2))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutIteration))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutGenerators))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutLambdas))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutScoringProject))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutClasses))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutNewStyleClasses))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutWithStatements))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutMonkeyPatching))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutDiceProject))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutMethodBindings))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutDecoratingWithFunctions))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutDecoratingWithClasses))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutInheritance))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutMultipleInheritance))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutScope))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutModules))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutPackages))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutClassAttributes))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutAttributeAccess))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutDeletingObjects))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutProxyObjectProject))
+#    suite.addTests(loader.loadTestsFromTestCase(TelevisionTest))
+#    suite.addTests(loader.loadTestsFromTestCase(AboutExtraCredit))
+
+    return suite

--- a/python_sql_koans/python2/runner/path_to_enlightenment.py
+++ b/python_sql_koans/python2/runner/path_to_enlightenment.py
@@ -5,7 +5,7 @@
 
 import unittest
 
-#from koans.about_asserts import AboutAsserts
+from koans.about_asserts import AboutAsserts
 from koans.about_select import AboutSelect
 from koans.about_where import AboutWhere
 from koans.about_groupby import AboutGroupBy

--- a/python_sql_koans/python2/runner/runner_tests/__init__.py
+++ b/python_sql_koans/python2/runner/runner_tests/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Namespace: helpers_tests

--- a/python_sql_koans/python2/runner/runner_tests/test_helper.py
+++ b/python_sql_koans/python2/runner/runner_tests/test_helper.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from runner import helper
+
+class TestHelper(unittest.TestCase):
+    
+    def test_that_get_class_name_works_with_a_string_instance(self):
+        self.assertEqual("str", helper.cls_name(str()))
+        
+    def test_that_get_class_name_works_with_a_4(self):
+        self.assertEquals("int", helper.cls_name(4))
+
+    def test_that_get_class_name_works_with_a_tuple(self):
+        self.assertEquals("tuple", helper.cls_name((3,"pie", [])))

--- a/python_sql_koans/python2/runner/runner_tests/test_mountain.py
+++ b/python_sql_koans/python2/runner/runner_tests/test_mountain.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+from libs.mock import *
+
+from runner.mountain import Mountain
+from runner import path_to_enlightenment
+
+class TestMountain(unittest.TestCase):
+
+    def setUp(self):
+        path_to_enlightenment.koans = Mock()
+        self.mountain = Mountain()
+        self.mountain.stream.writeln = Mock()
+        
+    def test_it_gets_test_results(self):
+        self.mountain.lesson.learn = Mock()
+        self.mountain.walk_the_path()
+        self.assertTrue(self.mountain.lesson.learn.called)
+        

--- a/python_sql_koans/python2/runner/runner_tests/test_sensei.py
+++ b/python_sql_koans/python2/runner/runner_tests/test_sensei.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+import unittest
+import re
+
+from libs.mock import *
+
+from runner.sensei import Sensei
+from runner.writeln_decorator import WritelnDecorator
+from runner.mockable_test_result import MockableTestResult
+from runner import path_to_enlightenment
+
+class AboutParrots:
+    pass
+class AboutLumberjacks:
+    pass
+class AboutTennis:
+    pass
+class AboutTheKnightsWhoSayNi:
+    pass
+class AboutMrGumby:
+    pass
+class AboutMessiahs:
+    pass
+class AboutGiantFeet:
+    pass
+class AboutTrebuchets:
+    pass
+class AboutFreemasons:
+    pass
+
+error_assertion_with_message = """Traceback (most recent call last):
+  File "/Users/Greg/hg/python_koans/koans/about_exploding_trousers.py", line 43, in test_durability
+    self.assertEqual("Steel","Lard", "Another fine mess you've got me into Stanley...")
+AssertionError: Another fine mess you've got me into Stanley..."""
+
+error_assertion_equals = """
+
+Traceback (most recent call last):
+  File "/Users/Greg/hg/python_koans/koans/about_exploding_trousers.py", line 49, in test_math
+    self.assertEqual(4,99)
+AssertionError: 4 != 99
+"""
+
+error_assertion_true = """Traceback (most recent call last):
+  File "/Users/Greg/hg/python_koans/koans/about_armories.py", line 25, in test_weoponary
+    self.assertTrue("Pen" > "Sword")
+AssertionError
+
+"""
+
+error_mess = """
+Traceback (most recent call last):
+  File "contemplate_koans.py", line 5, in <module>
+    from runner.mountain import Mountain
+  File "/Users/Greg/hg/python_koans/runner/mountain.py", line 7, in <module>
+    import path_to_enlightenment
+  File "/Users/Greg/hg/python_koans/runner/path_to_enlightenment.py", line 8, in <module>
+    from koans import *
+  File "/Users/Greg/hg/python_koans/koans/about_asserts.py", line 20
+    self.assertTrue(eoe"Pen" > "Sword", "nhnth")
+                           ^
+SyntaxError: invalid syntax"""
+
+error_with_list = """Traceback (most recent call last):
+  File "/Users/Greg/hg/python_koans/koans/about_armories.py", line 84, in test_weoponary
+    self.assertEqual([1, 9], [1, 2])
+AssertionError: Lists differ: [1, 9] != [1, 2]
+
+First differing element 1:
+9
+2
+
+- [1, 9]
+?     ^
+
++ [1, 2]
+?     ^
+
+"""
+
+class TestSensei(unittest.TestCase):
+
+    def setUp(self):
+        self.sensei = Sensei(WritelnDecorator(sys.stdout))
+        self.sensei.stream.writeln = Mock()
+        path_to_enlightenment.koans = Mock()
+        self.tests = Mock()
+        self.tests.countTestCases = Mock()
+        
+    def test_that_it_delegates_testing_to_test_cases(self):
+        MockableTestResult.startTest = Mock()
+        self.sensei.startTest(Mock())
+        self.assertTrue(MockableTestResult.startTest.called)
+        
+    def test_that_user_is_notified_if_test_involves_a_different_test_class_to_last_time(self):
+        MockableTestResult.startTest = Mock()
+        
+        self.sensei.prevTestClassName == 'AboutLumberjacks'
+        nextTest = AboutParrots()
+        
+        self.sensei.startTest(nextTest)
+        self.assertTrue(self.sensei.stream.writeln.called)
+        
+    def test_that_user_is_not_notified_about_test_class_repeats(self):
+        MockableTestResult.startTest = Mock()
+        
+        self.sensei.prevTestClassName == 'AboutParrots'
+        nextTest = AboutParrots()
+        
+        self.sensei.startTest(nextTest)
+        self.assertTrue(self.sensei.stream.writeln.called)
+    
+    def test_that_cached_classname_updates_after_the_test(self):
+        self.assertEqual(None, self.sensei.prevTestClassName)
+        self.sensei.startTest(Mock())
+        self.assertNotEqual(None, self.sensei.prevTestClassName)
+    
+    def test_that_errors_are_diverted_to_the_failures_list(self):
+        MockableTestResult.addFailure = Mock()
+        self.sensei.addError(Mock(), Mock())
+        self.assertTrue(MockableTestResult.addFailure.called)
+
+    def test_that_failures_are_handled_in_the_base_class(self):
+        MockableTestResult.addFailure = Mock()
+        self.sensei.addFailure(Mock(), Mock())
+        self.assertTrue(MockableTestResult.addFailure.called)
+
+    def test_that_it_successes_only_count_if_passes_are_currently_allowed(self):
+        self.sensei.passesCount = Mock()
+        MockableTestResult.addSuccess = Mock()
+        self.sensei.addSuccess(Mock())
+        self.assertTrue(self.sensei.passesCount.called)
+        
+    def test_that_if_there_are_failures_and_the_prev_class_is_different_successes_are_not_allowed(self):
+        self.sensei.failures = [(AboutLumberjacks(), Mock())]
+        self.sensei.prevTestClassName = "AboutTheMinitry"
+        self.assertFalse(self.sensei.passesCount())
+
+    def test_that_if_there_are_failures_and_the_prev_class_is_the_same_successes_are_allowed(self):
+        self.sensei.failures = [(AboutLumberjacks(), Mock())]
+        self.sensei.prevTestClassName = "AboutLumberjacks"
+        self.assertTrue(self.sensei.passesCount())
+
+    def test_that_if_there_are_no_failures_successes_are_allowed(self):
+        self.sensei.failures = None
+        self.sensei.prevTestClassName = "AboutLumberjacks"
+        self.assertTrue(self.sensei.passesCount())
+
+    def test_that_it_passes_on_add_successes_message(self):
+        MockableTestResult.addSuccess = Mock()
+        self.sensei.addSuccess(Mock())
+        self.assertTrue(MockableTestResult.addSuccess.called)
+            
+    def test_that_it_increases_the_passes_on_every_success(self):
+        pass_count = self.sensei.pass_count
+        MockableTestResult.addSuccess = Mock()
+        self.sensei.addSuccess(Mock())
+        self.assertEqual(pass_count + 1, self.sensei.pass_count)
+
+    def test_that_it_displays_each_success(self):
+        MockableTestResult.addSuccess = Mock()
+        self.sensei.addSuccess(Mock())
+        self.assertTrue(self.sensei.stream.writeln.called)
+                    
+    def test_that_nothing_is_returned_as_a_first_result_if_there_are_no_failures(self):
+        self.sensei.failures = []
+        self.assertEqual(None, self.sensei.firstFailure())
+    
+    def test_that_nothing_is_returned_as_sorted_result_if_there_are_no_failures(self):
+        self.sensei.failures = []
+        self.assertEqual(None, self.sensei.sortFailures("AboutLife"))
+    
+    def test_that_nothing_is_returned_as_sorted_result_if_there_are_no_relevent_failures(self):
+        self.sensei.failures = [
+            (AboutTheKnightsWhoSayNi(),"File 'about_the_knights_whn_say_ni.py', line 24"),
+            (AboutMessiahs(),"File 'about_messiahs.py', line 43"),
+            (AboutMessiahs(),"File 'about_messiahs.py', line 844")
+        ]
+        self.assertEqual(None, self.sensei.sortFailures("AboutLife"))
+    
+    def test_that_nothing_is_returned_as_sorted_result_if_there_are_3_shuffled_results(self):
+        self.sensei.failures = [
+            (AboutTennis(),"File 'about_tennis.py', line 299"),
+            (AboutTheKnightsWhoSayNi(),"File 'about_the_knights_whn_say_ni.py', line 24"),
+            (AboutTennis(),"File 'about_tennis.py', line 30"),
+            (AboutMessiahs(),"File 'about_messiahs.py', line 43"),
+            (AboutTennis(),"File 'about_tennis.py', line 2"),
+            (AboutMrGumby(),"File 'about_mr_gumby.py', line odd"),
+            (AboutMessiahs(),"File 'about_messiahs.py', line 844")
+        ]
+        
+        expected = [
+            (AboutTennis(),"File 'about_tennis.py', line 2"),
+            (AboutTennis(),"File 'about_tennis.py', line 30"),
+            (AboutTennis(),"File 'about_tennis.py', line 299")
+        ]
+        
+        results = self.sensei.sortFailures("AboutTennis")
+        self.assertEqual(3, len(results))
+        self.assertEqual(2, results[0][0])
+        self.assertEqual(30, results[1][0])
+        self.assertEqual(299, results[2][0])
+    
+    def test_that_it_will_choose_not_find_anything_with_non_standard_error_trace_string(self):
+        self.sensei.failures = [
+            (AboutMrGumby(),"File 'about_mr_gumby.py', line MISSING"),
+        ]
+        self.assertEqual(None, self.sensei.sortFailures("AboutMrGumby"))
+    
+    
+    def test_that_it_will_choose_correct_first_result_with_lines_9_and_27(self):
+        self.sensei.failures = [
+            (AboutTrebuchets(),"File 'about_trebuchets.py', line 27"),
+            (AboutTrebuchets(),"File 'about_trebuchets.py', line 9"),
+            (AboutTrebuchets(),"File 'about_trebuchets.py', line 73v")
+        ]
+        self.assertEqual("File 'about_trebuchets.py', line 9", self.sensei.firstFailure()[1])
+    
+    def test_that_it_will_choose_correct_first_result_with_multiline_test_classes(self):
+        self.sensei.failures = [
+            (AboutGiantFeet(),"File 'about_giant_feet.py', line 999"),
+            (AboutGiantFeet(),"File 'about_giant_feet.py', line 44"),
+            (AboutFreemasons(),"File 'about_freemasons.py', line 1"),
+            (AboutFreemasons(),"File 'about_freemasons.py', line 11")
+        ]
+        self.assertEqual("File 'about_giant_feet.py', line 44", self.sensei.firstFailure()[1])
+            
+    def test_that_end_report_displays_something(self):
+        self.sensei.learn()
+        self.assertTrue(self.sensei.stream.writeln.called)
+
+    def test_that_end_report_shows_student_progress(self):
+        self.sensei.errorReport = Mock()
+        self.sensei.total_lessons = Mock()
+        self.sensei.total_koans = Mock()
+
+        self.sensei.learn()
+        self.assertTrue(self.sensei.total_lessons.called)
+        self.assertTrue(self.sensei.total_koans.called)     
+
+    def test_that_end_report_shows_the_failure_report(self):
+        self.sensei.errorReport = Mock()
+        self.sensei.learn()
+        self.assertTrue(self.sensei.errorReport.called)
+
+    def test_that_end_report_should_have_something_zenlike_on_it(self):
+        self.sensei.say_something_zenlike = Mock()
+        self.sensei.learn()
+        self.assertTrue(self.sensei.say_something_zenlike.called)
+
+    def test_that_error_report_shows_something_if_there_is_a_failure(self):
+        self.sensei.firstFailure = Mock()
+        self.sensei.firstFailure.return_value = (Mock(), "FAILED Parrot is breathing, Line 42")
+        self.sensei.errorReport()
+        self.assertTrue(self.sensei.stream.writeln.called)
+
+    def test_that_error_report_does_not_show_anything_if_there_is_no_failure(self):
+        self.sensei.firstFailure = Mock()
+        self.sensei.firstFailure.return_value = None
+        self.sensei.errorReport()
+        self.assertFalse(self.sensei.stream.writeln.called)
+        
+    def test_that_error_report_features_the_assertion_error(self):
+        self.sensei.scrapeAssertionError = Mock()
+        self.sensei.firstFailure = Mock()
+        self.sensei.firstFailure.return_value = (Mock(), "FAILED")
+        self.sensei.errorReport()
+        self.assertTrue(self.sensei.scrapeAssertionError.called)
+
+    def test_that_error_report_features_a_stack_dump(self):
+        self.sensei.scrapeInterestingStackDump = Mock()
+        self.sensei.firstFailure = Mock()
+        self.sensei.firstFailure.return_value = (Mock(), "FAILED")
+        self.sensei.errorReport()
+        self.assertTrue(self.sensei.scrapeInterestingStackDump.called)
+
+    def test_that_scraping_the_assertion_error_with_nothing_gives_you_a_blank_back(self):
+        self.assertEqual("", self.sensei.scrapeAssertionError(None))
+        
+    def test_that_scraping_the_assertion_error_with_messaged_assert(self):
+        self.assertEqual("  AssertionError: Another fine mess you've got me into Stanley...",
+            self.sensei.scrapeAssertionError(error_assertion_with_message))
+        
+    def test_that_scraping_the_assertion_error_with_assert_equals(self):
+        self.assertEqual("  AssertionError: 4 != 99",
+            self.sensei.scrapeAssertionError(error_assertion_equals))
+        
+    def test_that_scraping_the_assertion_error_with_assert_true(self):
+        self.assertEqual("  AssertionError",
+            self.sensei.scrapeAssertionError(error_assertion_true))
+        
+    def test_that_scraping_the_assertion_error_with_syntax_error(self):
+        self.assertEqual("  SyntaxError: invalid syntax",
+            self.sensei.scrapeAssertionError(error_mess))
+
+    def test_that_scraping_the_assertion_error_with_list_error(self):
+        self.assertEqual("""  AssertionError: Lists differ: [1, 9] != [1, 2]
+
+  First differing element 1:
+  9
+  2
+
+  - [1, 9]
+  ?     ^
+
+  + [1, 2]
+  ?     ^""",
+            self.sensei.scrapeAssertionError(error_with_list))
+
+    def test_that_scraping_a_non_existent_stack_dump_gives_you_nothing(self):
+        self.assertEqual("", self.sensei.scrapeInterestingStackDump(None))
+        
+    def test_that_scraping_the_stack_dump_only_shows_interesting_lines_for_messaged_assert(self):
+        expected = """  File "/Users/Greg/hg/python_koans/koans/about_exploding_trousers.py", line 43, in test_durability
+    self.assertEqual("Steel","Lard", "Another fine mess you've got me into Stanley...")"""
+        self.assertEqual(expected,
+            self.sensei.scrapeInterestingStackDump(error_assertion_with_message))
+
+    def test_that_scraping_the_stack_dump_only_shows_interesting_lines_for_assert_equals(self):
+        expected = """  File "/Users/Greg/hg/python_koans/koans/about_exploding_trousers.py", line 49, in test_math
+    self.assertEqual(4,99)"""
+        self.assertEqual(expected,
+            self.sensei.scrapeInterestingStackDump(error_assertion_equals))
+
+    def test_that_scraping_the_stack_dump_only_shows_interesting_lines_for_assert_true(self):
+        expected = """  File "/Users/Greg/hg/python_koans/koans/about_armories.py", line 25, in test_weoponary
+    self.assertTrue("Pen" > "Sword")"""
+        self.assertEqual(expected,
+            self.sensei.scrapeInterestingStackDump(error_assertion_true))
+
+    def test_that_scraping_the_stack_dump_only_shows_interesting_lines_for_syntax_error(self):
+        expected = """  File "/Users/Greg/hg/python_koans/koans/about_asserts.py", line 20
+    self.assertTrue(eoe"Pen" > "Sword", "nhnth")"""
+        self.assertEqual(expected,
+            self.sensei.scrapeInterestingStackDump(error_mess))
+        
+    def test_that_if_there_are_no_failures_say_the_final_zenlike_remark(self):
+        self.sensei.failures = None
+        words = self.sensei.say_something_zenlike()
+        
+        m = re.search("Spanish Inquisition", words)
+        self.assertTrue(m and m.group(0))
+        
+    def test_that_if_there_are_0_successes_it_will_say_the_first_zen_of_python_koans(self):
+        self.sensei.pass_count = 0
+        self.sensei.failures = Mock()
+        words = self.sensei.say_something_zenlike()
+        
+        m = re.search("Beautiful is better than ugly", words)
+        self.assertTrue(m and m.group(0))
+        
+    def test_that_if_there_is_1_successes_it_will_say_the_second_zen_of_python_koans(self):
+        self.sensei.pass_count = 1
+        self.sensei.failures = Mock()
+        words = self.sensei.say_something_zenlike()
+                
+        m = re.search("Explicit is better than implicit", words)
+        self.assertTrue(m and m.group(0))
+
+    def test_that_if_there_is_10_successes_it_will_say_the_sixth_zen_of_python_koans(self):
+        self.sensei.pass_count = 10
+        self.sensei.failures = Mock()
+        words = self.sensei.say_something_zenlike()
+                
+        m = re.search("Sparse is better than dense", words)
+        self.assertTrue(m and m.group(0))
+
+    def test_that_if_there_is_36_successes_it_will_say_the_final_zen_of_python_koans(self):
+        self.sensei.pass_count = 36
+        self.sensei.failures = Mock()
+        words = self.sensei.say_something_zenlike()
+                
+        m = re.search("Namespaces are one honking great idea", words)
+        self.assertTrue(m and m.group(0))
+
+    def test_that_if_there_is_37_successes_it_will_say_the_first_zen_of_python_koans_again(self):
+        self.sensei.pass_count = 37
+        self.sensei.failures = Mock()
+        words = self.sensei.say_something_zenlike()
+        
+        m = re.search("Beautiful is better than ugly", words)
+        self.assertTrue(m and m.group(0))
+
+    def test_that_total_lessons_return_7_if_there_are_7_lessons(self):
+        self.sensei.filter_all_lessons = Mock()
+        self.sensei.filter_all_lessons.return_value = [1,2,3,4,5,6,7]
+
+        self.assertEqual(7, self.sensei.total_lessons())
+
+    def test_that_total_lessons_return_0_if_all_lessons_is_none(self):
+        self.sensei.filter_all_lessons = Mock()
+        self.sensei.filter_all_lessons.return_value = None
+
+        self.assertEqual(0, self.sensei.total_lessons())
+
+    def test_total_koans_return_43_if_there_are_43_test_cases(self):
+        self.sensei.tests.countTestCases = Mock()
+        self.sensei.tests.countTestCases.return_value = 43
+        
+        self.assertEqual(43, self.sensei.total_koans())
+
+    def test_filter_all_lessons_will_discover_test_classes_if_none_have_been_discovered_yet(self):
+        self.sensei.all_lessons = 0
+        self.assertTrue(len(self.sensei.filter_all_lessons()) > 10)
+        self.assertTrue(len(self.sensei.all_lessons) > 10)

--- a/python_sql_koans/python2/runner/sensei.py
+++ b/python_sql_koans/python2/runner/sensei.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+import re
+import glob
+
+import helper
+from mockable_test_result import MockableTestResult
+from runner import path_to_enlightenment
+
+from libs.colorama import init, Fore, Style
+init() # init colorama
+
+class Sensei(MockableTestResult):
+    def __init__(self, stream):
+        unittest.TestResult.__init__(self)
+        self.stream = stream
+        self.prevTestClassName = None
+        self.tests = path_to_enlightenment.koans()        
+        self.pass_count = 0
+        self.lesson_pass_count  = 0
+        self.all_lessons = None
+
+    def startTest(self, test):
+        MockableTestResult.startTest(self, test)
+
+        if helper.cls_name(test) != self.prevTestClassName:
+            self.prevTestClassName = helper.cls_name(test)
+            if not self.failures:
+                self.stream.writeln()
+                self.stream.writeln("{0}{1}Thinking {2}".format(
+                    Fore.RESET, Style.NORMAL, helper.cls_name(test)))
+                if helper.cls_name(test) != 'AboutAsserts':
+                    self.lesson_pass_count += 1
+
+    def addSuccess(self, test):
+        if self.passesCount():            
+            MockableTestResult.addSuccess(self, test)
+            self.stream.writeln( \
+                "  {0}{1}{2} has expanded your awareness.{3}{4}" \
+                .format(Fore.GREEN, Style.BRIGHT, test._testMethodName, \
+                Fore.RESET, Style.NORMAL))      
+            self.pass_count += 1
+
+    def addError(self, test, err):
+        # Having 1 list for errors and 1 list for failures would mess with
+        # the error sequence
+        self.addFailure(test, err)
+
+    def passesCount(self):
+        return not (self.failures and helper.cls_name(self.failures[0][0]) !=
+                    self.prevTestClassName)
+        
+    def addFailure(self, test, err):
+        MockableTestResult.addFailure(self, test, err)
+
+    def sortFailures(self, testClassName):
+        table = list()
+        for test, err in self.failures:
+            if helper.cls_name(test) ==  testClassName:
+                m = re.search("(?<= line )\d+" ,err)
+                if m:
+                    tup = (int(m.group(0)), test, err)
+                    table.append(tup)
+               
+        if table:
+            return sorted(table)
+        else:
+            return None
+         
+    def firstFailure(self):
+        if not self.failures: return None
+        
+        table = self.sortFailures(helper.cls_name(self.failures[0][0]))
+            
+        if table:
+            return (table[0][1], table[0][2])
+        else:
+            return None
+    
+    def learn(self):
+        self.errorReport()
+    
+        self.stream.writeln("")
+        self.stream.writeln("")
+        self.stream.writeln(self.report_progress())
+        self.stream.writeln("")
+        self.stream.writeln(self.say_something_zenlike())
+        
+        if self.failures: return
+        self.stream.writeln(
+            "\n{0}**************************************************" \
+            .format(Fore.RESET))
+        self.stream.writeln("\n{0}That was the last one, well done!" \
+            .format(Fore.MAGENTA))
+        self.stream.writeln(
+            "\nIf you want more, take a look at about_extra_credit_task.py")
+        
+    def errorReport(self):
+        problem = self.firstFailure()
+        if not problem: return 
+        test, err = problem 
+        self.stream.writeln("  {0}{1}{2} has damaged your "
+          "karma.".format(Fore.RED, Style.BRIGHT, test._testMethodName))        
+
+        self.stream.writeln("\n{0}{1}You have not yet reached enlightenment ..." \
+            .format(Fore.RESET, Style.NORMAL))
+        self.stream.writeln("{0}{1}{2}".format(Fore.RED, \
+            Style.BRIGHT, self.scrapeAssertionError(err)))
+        self.stream.writeln("")
+        self.stream.writeln("{0}{1}Please meditate on the following code:" \
+            .format(Fore.RESET, Style.NORMAL))
+        self.stream.writeln("{0}{1}{2}{3}{4}".format(Fore.YELLOW, Style.BRIGHT, \
+            self.scrapeInterestingStackDump(err), Fore.RESET, Style.NORMAL))
+
+    def scrapeAssertionError(self, err):
+        if not err: return ""
+
+        error_text = ""
+        count = 0
+        for line in err.splitlines():
+            m = re.search("^[^^ ].*$",line)
+            if m and m.group(0):
+                count+=1
+            
+            if count>1:
+                error_text += ("  " + line.strip()).rstrip() + '\n'
+        return error_text.strip('\n')
+
+    def scrapeInterestingStackDump(self, err):
+        if not err:
+            return ""
+
+        lines = err.splitlines()
+        
+        sep = '@@@@@SEP@@@@@'
+        
+        scrape = ""
+        for line in lines:
+            m = re.search("^  File .*$",line)
+            if m and m.group(0):
+                scrape += '\n' + line
+
+            m = re.search("^    \w(\w)+.*$",line)
+            if m and m.group(0):
+                scrape += sep + line
+            
+        lines = scrape.splitlines()
+                        
+        scrape = ""
+        for line in lines:
+            m = re.search("^.*[/\\\\]koans[/\\\\].*$",line)
+            if m and m.group(0):
+                scrape += line + '\n'
+        return scrape.replace(sep, '\n').strip('\n')
+
+    def report_progress(self):
+        return ("You are now {0}/{1} koans and {2}/{3} lessons away from " \
+                "reaching enlightenment".format(self.pass_count,
+                                                self.total_koans(),
+                                                self.lesson_pass_count,
+                                                self.total_lessons()))
+
+    # Hat's tip to Tim Peters for the zen statements from The Zen
+    # of Python (http://www.python.org/dev/peps/pep-0020/)
+    #
+    # Also a hat's tip to Ara T. Howard for the zen statements from his
+    # metakoans Ruby Quiz (http://rubyquiz.com/quiz67.html) and
+    # Edgecase's later permatation in the Ruby Koans
+    def say_something_zenlike(self):
+        if self.failures:
+            turn = self.pass_count % 37
+
+            zenness = "";
+            if turn == 0:            
+                zenness = "Beautiful is better than ugly."
+            elif turn == 1 or turn == 2:
+                zenness = "Explicit is better than implicit."
+            elif turn == 3 or turn == 4:
+                zenness = "Simple is better than complex."
+            elif turn == 5 or turn == 6:
+                zenness = "Complex is better than complicated."
+            elif turn == 7 or turn == 8:
+                zenness = "Flat is better than nested."
+            elif turn == 9 or turn == 10:
+                zenness = "Sparse is better than dense."
+            elif turn == 11 or turn == 12:
+                zenness = "Readability counts."
+            elif turn == 13 or turn == 14:
+                zenness = "Special cases aren't special enough to " \
+                          "break the rules."
+            elif turn == 15 or turn == 16:
+                zenness = "Although practicality beats purity."
+            elif turn == 17 or turn == 18:
+                zenness = "Errors should never pass silently."
+            elif turn == 19 or turn == 20:
+                zenness = "Unless explicitly silenced."
+            elif turn == 21 or turn == 22:
+                zenness = "In the face of ambiguity, refuse the " \
+                          "temptation to guess."
+            elif turn == 23 or turn == 24:
+                zenness = "There should be one-- and preferably only " \
+                          "one --obvious way to do it."
+            elif turn == 25 or turn == 26:
+                zenness = "Although that way may not be obvious at " \
+                          "first unless you're Dutch."
+            elif turn == 27 or turn == 28:
+                zenness = "Now is better than never."
+            elif turn == 29 or turn == 30:
+                zenness = "Although never is often better than right " \
+                          "now."
+            elif turn == 31 or turn == 32:
+                zenness = "If the implementation is hard to explain, " \
+                          "it's a bad idea."
+            elif turn == 33 or turn == 34:
+                zenness = "If the implementation is easy to explain, " \
+                          "it may be a good idea."
+            else: 
+                zenness = "Namespaces are one honking great idea -- " \
+                          "let's do more of those!"
+            return "{0}{1}{2}{3}".format(Fore.CYAN, zenness, Fore.RESET, Style.NORMAL); 
+        else:
+            return "{0}Nobody ever expects the Spanish Inquisition." \
+                .format(Fore.CYAN)
+        
+        # Hopefully this will never ever happen!
+        return "The temple in collapsing! Run!!!"
+
+    def total_lessons(self):
+        all_lessons = self.filter_all_lessons()
+        if all_lessons:
+          return len(all_lessons)
+        else:
+          return 0
+
+    def total_koans(self):
+        return self.tests.countTestCases()
+
+    def filter_all_lessons(self):
+        if not self.all_lessons:
+            self.all_lessons = glob.glob('koans/about*.py')
+            self.all_lessons = filter(lambda filename:
+                                      "about_extra_credit" not in filename,
+                                      self.all_lessons)
+            
+        return self.all_lessons

--- a/python_sql_koans/python2/runner/writeln_decorator.py
+++ b/python_sql_koans/python2/runner/writeln_decorator.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+import sys
+import os
+
+# Taken from legacy python unittest
+class WritelnDecorator:
+    """Used to decorate file-like objects with a handy 'writeln' method"""
+    def __init__(self,stream):
+        self.stream = stream
+
+    def __getattr__(self, attr):
+        return getattr(self.stream,attr)
+
+    def writeln(self, arg=None):
+        if arg: self.write(arg)
+        self.write('\n') # text-mode streams translate to \r\n if needed
+

--- a/python_sql_koans/python3/README
+++ b/python_sql_koans/python3/README
@@ -1,0 +1,4 @@
+This is UNDER CONSTRUCTION....
+
+it should include the ideas from python2 version with the syntax and patterns of python 3.
+


### PR DESCRIPTION
This commit adds a skeleton of unit tests for teaching sql thru a test-driven-design appoach leveraging the structure of python koans here:  https://github.com/gregmalcolm/python_koans/wiki

This could provide a tool for decentralized learning in a tutorial as students work on fixing assertions while mentors circle the room searching for high frustration levels like a metaphoric vulture.

This includes hooks for koans not just about sqlite3 but sqlalchemy.  Ideally showing typically uses, highlighting avoidance of typical problems. 

These koans can be run as they are by typing 'python contemplate_koans.py'  at the prompt in the python_sql_koans folder.
